### PR TITLE
EPEL release match

### DIFF
--- a/attributes/epel-debuginfo.rb
+++ b/attributes/epel-debuginfo.rb
@@ -14,11 +14,11 @@ else
   when 6
     default['yum']['epel-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Debug'
     default['yum']['epel-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch'
-    default['yum']['epel-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   when 7
     default['yum']['epel-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch - Debug'
     default['yum']['epel-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-7&arch=$basearch'
-    default['yum']['epel-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 end
 

--- a/attributes/epel-source.rb
+++ b/attributes/epel-source.rb
@@ -13,11 +13,11 @@ else
     default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
   when 6
     default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Source'
-    default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=$basearch'
+    default['yum']['epel-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch'
     default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   when 7
     default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch - Source'
-    default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-7&arch=$basearch'
+    default['yum']['epel-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-7&arch=$basearch'
     default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 end

--- a/attributes/epel-source.rb
+++ b/attributes/epel-source.rb
@@ -14,11 +14,11 @@ else
   when 6
     default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Source'
     default['yum']['epel-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch'
-    default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   when 7
     default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch - Source'
     default['yum']['epel-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-source-7&arch=$basearch'
-    default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 end
 

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -13,11 +13,11 @@ else
     default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
   when 6
     default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
-    default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
+    default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
     default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   when 7
     default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
-    default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch'
+    default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
     default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 end

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -14,11 +14,11 @@ else
   when 6
     default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
     default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-    default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   when 7
     default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
     default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-    default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 end
 


### PR DESCRIPTION
This pull request puts yum-epel in line with epel-release RPMs for EPEL 5/6/7, and pulls the gpgkey from https on EPEL 6/7 (as the mirrorlists also use https).

The two issues this solves is:

* GPG public key being able to be replaced with another via a MITM - this is solved using https with SSL certificate verification for the GPG key
* Unverified repodata allowing stale mirrors, giving bad mirrors/MITM the ability to give old packages with known security issues in, then attack the servers using exploits for those issues.

I understand this work was previously reverted due to complaints however:

* The same would be the case for them installing epel-release
* They can always turn off sslverify for the repos
* They can always also specify the http url themselves
* Semantic versioning should take care of people finding BC issues. If not (through lack of ~> x.y.z), it's their problem, not the people who want assurance on security.
* The damage of having a MITM push a different gpg key and exploit the servers is far more serious than some complaints
* The damage of having a bad proxy or MITM force stale packages with known exploits is ...