### PR TITLE
updated to utilize `make_cache` parameter from yum cookbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # yum-epel Cookbook CHANGELOG
 This file is used to list changes made in each version of the yum-epel cookbook.
 
+## v0.6.5
+- updated to use `make_cache` option that yum cookbook allows for the yum resource to use.
+
+
 ## v0.6.5 (2015-11-23)
 - Fix setting bool false properties
 

--- a/attributes/epel-debuginfo.rb
+++ b/attributes/epel-debuginfo.rb
@@ -26,3 +26,4 @@ default['yum']['epel-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-debuginfo']['gpgcheck'] = true
 default['yum']['epel-debuginfo']['enabled'] = false
 default['yum']['epel-debuginfo']['managed'] = false
+default['yum']['epel-debuginfo']['make_cache'] = true

--- a/attributes/epel-source.rb
+++ b/attributes/epel-source.rb
@@ -26,3 +26,4 @@ default['yum']['epel-source']['failovermethod'] = 'priority'
 default['yum']['epel-source']['gpgcheck'] = true
 default['yum']['epel-source']['enabled'] = false
 default['yum']['epel-source']['managed'] = false
+default['yum']['epel-source']['make_cache'] = true

--- a/attributes/epel-testing-debuginfo.rb
+++ b/attributes/epel-testing-debuginfo.rb
@@ -26,3 +26,4 @@ default['yum']['epel-testing-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-testing-debuginfo']['gpgcheck'] = true
 default['yum']['epel-testing-debuginfo']['enabled'] = false
 default['yum']['epel-testing-debuginfo']['managed'] = false
+default['yum']['epel-testing-debuginfo']['make_cache'] = true

--- a/attributes/epel-testing-source.rb
+++ b/attributes/epel-testing-source.rb
@@ -26,3 +26,4 @@ default['yum']['epel-testing-source']['failovermethod'] = 'priority'
 default['yum']['epel-testing-source']['gpgcheck'] = true
 default['yum']['epel-testing-source']['enabled'] = false
 default['yum']['epel-testing-source']['managed'] = false
+default['yum']['epel-testing-source']['make_cache'] = true

--- a/attributes/epel-testing.rb
+++ b/attributes/epel-testing.rb
@@ -26,3 +26,4 @@ default['yum']['epel-testing']['failovermethod'] = 'priority'
 default['yum']['epel-testing']['gpgcheck'] = true
 default['yum']['epel-testing']['enabled'] = false
 default['yum']['epel-testing']['managed'] = false
+default['yum']['epel-testing']['make_cache'] = true

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -26,3 +26,4 @@ default['yum']['epel']['failovermethod'] = 'priority'
 default['yum']['epel']['gpgcheck'] = true
 default['yum']['epel']['enabled'] = true
 default['yum']['epel']['managed'] = true
+default['yum']['epel']['make_cache'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Chef Software, Inc.'
 maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Installs and configures the EPEL Yum repository'
-version '0.6.5'
+version '0.6.6'
 
 depends 'yum', '~> 3.10.0'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Installs and configures the EPEL Yum repository'
 version '0.6.5'
 
-depends 'yum', '~> 3.2'
+depends 'yum', '~> 3.10.0'
 
 %w(amazon centos fedora oracle redhat scientific).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,7 @@ node['yum-epel']['repositories'].each do |repo|
     include_config node['yum'][repo]['include_config'] unless node['yum'][repo]['include_config'].nil?
     includepkgs node['yum'][repo]['includepkgs'] unless node['yum'][repo]['includepkgs'].nil?
     keepalive node['yum'][repo]['keepalive'] unless node['yum'][repo]['keepalive'].nil?
+    make_cache node['yum'][repo]['make_cache'] unless node['yum'][repo]['make_cache'].nil?
     max_retries node['yum'][repo]['max_retries'] unless node['yum'][repo]['max_retries'].nil?
     metadata_expire node['yum'][repo]['metadata_expire'] unless node['yum'][repo]['metadata_expire'].nil?
     mirror_expire node['yum'][repo]['mirror_expire'] unless node['yum'][repo]['mirror_expire'].nil?


### PR DESCRIPTION
this cookbook doesn't utilize the make_cache option that the parent yum cookbook has. this fix allows that attribute/value to be passed in now then as an attribute, and so you don't have to just make a custom yum resource if you wanted to actually not do make_cache.
