### PR TITLE
Added epel repositories for Linux on Z(s390x)

### DIFF
--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -1,6 +1,6 @@
 default['yum']['epel']['repositoryid'] = 'epel'
 
-case node[:kernel][:machine]
+case node['kernel']['machine']
 when 's390x'
   default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
   default['yum']['epel']['baseurl'] = 'https://kojipkgs.fedoraproject.org/rhel/rc/7/Server/s390x/os/'

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -27,6 +27,7 @@ else
       default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
     end
   end
+end
 
 default['yum']['epel']['failovermethod'] = 'priority'
 default['yum']['epel']['gpgcheck'] = true

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -1,26 +1,32 @@
 default['yum']['epel']['repositoryid'] = 'epel'
 
-case node['platform']
-when 'amazon'
-  default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
-  default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
-  default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+case node[:kernel][:machine]
+when 's390x'
+  default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
+  default['yum']['epel']['baseurl'] = 'https://kojipkgs.fedoraproject.org/rhel/rc/7/Server/s390x/os/'
+  default['yum']['epel']['gpgkey'] = 'https://kojipkgs.fedoraproject.org/rhel/rc/7/Server/s390x/os/RPM-GPG-KEY-redhat-release'
 else
-  case node['platform_version'].to_i
-  when 5
-    default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 5 - $basearch'
-    default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch'
-    default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
-  when 6
+  case node['platform']
+  when 'amazon'
     default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
-    default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-    default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
-  when 7
-    default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
-    default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-    default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
+    default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+  else
+    case node['platform_version'].to_i
+    when 5
+      default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 5 - $basearch'
+      default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch'
+      default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
+    when 6
+      default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
+      default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+      default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    when 7
+      default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 7 - $basearch'
+      default['yum']['epel']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+      default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    end
   end
-end
 
 default['yum']['epel']['failovermethod'] = 'priority'
 default['yum']['epel']['gpgcheck'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version '0.6.6'
 
 depends 'yum', '~> 3.10.0'
 
-%w(amazon centos fedora oracle redhat scientific).each do |os|
+%w(amazon centos fedora oracle redhat scientific zlinux).each do |os|
   supports os
 end
 


### PR DESCRIPTION
Repositories were required to download specific dependencies. To support the same we have added necessary repositories for Linux on Z(s390x)
Also added support for Linux on Z(s390x)