### PR TITLE
fix epel-testing attributes copy/paste error

### DIFF
--- a/attributes/epel-testing.rb
+++ b/attributes/epel-testing.rb
@@ -1,11 +1,11 @@
 default['yum']['epel-testing']['repositoryid'] = 'epel-testing'
 default['yum']['epel-testing']['description'] = 'Extra Packages for $releasever - $basearch - Testing '
 if node['platform'] == 'amazon'
-  default['yum']['epel-testing-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=$basearch'
-  default['yum']['epel-testing-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+  default['yum']['epel-testing']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=$basearch'
+  default['yum']['epel-testing']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 else
-  default['yum']['epel-testing-source']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-testing-source']['gpgkey'] = (node['platform_version'].to_i == 5 ? 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL' : "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}")
+  default['yum']['epel-testing']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{node['platform_version'].to_i}&arch=$basearch"
+  default['yum']['epel-testing']['gpgkey'] = (node['platform_version'].to_i == 5 ? 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL' : "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}")
 end
 
 default['yum']['epel-testing']['failovermethod'] = 'priority'


### PR DESCRIPTION
### Description

Fixed what looks like a copy and paste error. If running EL6 the epel-testing repo doesn't get a mirrorlist, which breaks yum if you include that repo.

### Issues Resolved

Well, it would resolve the issue that broke my stuff.

### Check List
take it or leave it... create another pull request... whatever.