### PR TITLE
Fix issue with multiple metadata 'depends' specs

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs and configures the EPEL Yum repository'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.1'
 
-depends 'yum', '>= 3.6', '< 5.0'
+depends 'yum', '>= 3.6'
 
 %w(amazon centos oracle redhat scientific zlinux).each do |os|
   supports os


### PR DESCRIPTION
```
Newer versions of Chef disallow 'depends' clauses from contining more
than one version constraint. This commit removes the upper version
constraint, leaving only the minimum version constraint.

Obvious fix.
```

Solves https://github.com/chef-cookbooks/yum-epel/issues/38


