### PR TITLE
Removing dependency to yum cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ The yum-epel cookbook takes over management of the default repositoryids shipped
 ### Chef
 - Chef 12+
 
-### Cookbooks
-- yum version 3.6.3 or higher
-
 ## Attributes
 The following attributes are set by default
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,12 +6,10 @@ description 'Installs and configures the EPEL Yum repository'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.0.2'
 
-depends 'yum', '>= 3.6'
-
 %w(amazon centos oracle redhat scientific zlinux).each do |os|
   supports os
 end
 
 source_url 'https://github.com/chef-cookbooks/yum-epel'
 issues_url 'https://github.com/chef-cookbooks/yum-epel/issues'
-chef_version '>= 12'
+chef_version '>= 12.15.19'


### PR DESCRIPTION
### Description

Removes the dependency to yum cookbook, as `yum_repository` is available in chef.

Right now following warnings are generated if yum-epel is in the cookbook dependency tree:
```
       [2016-11-03T13:55:37+01:00] WARN: Chef::Provider::YumRepository already exists!  Cannot create deprecation class for LWRP provider yum_repository from cookbook yum
       [2016-11-03T13:55:37+01:00] WARN: YumRepository already exists!  Deprecation class overwrites Custom resource yum_repository from cookbook yum
```

- Starting from chef 12.14.60, yum_repository is available in chef
- Starting from chef 12.15.19 it seems to have the same defaults
  and behaviour as yum cookbook. So I used this version as chef requirement