### PR TITLE
Support EPEL on ARM32.

### DIFF
--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -1,6 +1,10 @@
 default['yum']['epel']['repositoryid'] = 'epel'
 default['yum']['epel']['description'] = "Extra Packages for #{node['platform_version'].to_i} - $basearch"
+default['yum']['epel']['gpgcheck'] = true
 case node['kernel']['machine']
+when 'armv7l','armv7hl'
+  default['yum']['epel']['baseurl'] = 'https://armv7.dev.centos.org/repodir/epel-pass-1/'
+  default['yum']['epel']['gpgcheck'] = false
 when 's390x'
   default['yum']['epel']['baseurl'] = 'https://kojipkgs.fedoraproject.org/rhel/rc/7/Server/s390x/os/'
   default['yum']['epel']['gpgkey'] = 'https://kojipkgs.fedoraproject.org/rhel/rc/7/Server/s390x/os/RPM-GPG-KEY-redhat-release'
@@ -24,7 +28,6 @@ else
   end
 end
 default['yum']['epel']['failovermethod'] = 'priority'
-default['yum']['epel']['gpgcheck'] = true
 default['yum']['epel']['enabled'] = true
 default['yum']['epel']['managed'] = true
 default['yum']['epel']['make_cache'] = true

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -2,7 +2,7 @@ default['yum']['epel']['repositoryid'] = 'epel'
 default['yum']['epel']['description'] = "Extra Packages for #{node['platform_version'].to_i} - $basearch"
 default['yum']['epel']['gpgcheck'] = true
 case node['kernel']['machine']
-when 'armv7l','armv7hl'
+when 'armv7l', 'armv7hl'
   default['yum']['epel']['baseurl'] = 'https://armv7.dev.centos.org/repodir/epel-pass-1/'
   default['yum']['epel']['gpgcheck'] = false
 when 's390x'


### PR DESCRIPTION
### Description

The [CentOS AltArch/ARM32 SIG](https://wiki.centos.org/SpecialInterestGroup/AltArch/Arm32) maintains a rebuild of EPEL for 32-bit ARM machines. This change allows Chef on 32-bit ARM architectures to take advantage of it, instead of attempting to use Fedora's (Intel-only) EPEL.

This was tested against CentOS 7 on a Raspberry Pi 2.

### Issues Resolved

None; new feature.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
