### PR TITLE
Switch gpgkey urls from (http/https)://download.xxx to https://dl.xxx

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ default['yum-epel']['repos'] = %w(
 default['yum']['epel']['repositoryid'] = 'epel'
 default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
 default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch'
-default['yum']['epel']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel']['failovermethod'] = 'priority'
 default['yum']['epel']['gpgcheck'] = true
 default['yum']['epel']['enabled'] = true
@@ -50,7 +50,7 @@ default['yum']['epel']['managed'] = true
 default['yum']['epel-debuginfo']['repositoryid'] = 'epel-debuginfo'
 default['yum']['epel-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Debug'
 default['yum']['epel-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch'
-default['yum']['epel-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-debuginfo']['gpgcheck'] = true
 default['yum']['epel-debuginfo']['enabled'] = false
@@ -61,7 +61,7 @@ default['yum']['epel-debuginfo']['managed'] = false
 default['yum']['epel-source']['repositoryid'] = 'epel-source'
 default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Source'
 default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=$basearch'
-default['yum']['epel-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-source']['failovermethod'] = 'priority'
 default['yum']['epel-source']['gpgcheck'] = true
 default['yum']['epel-source']['enabled'] = false
@@ -72,7 +72,7 @@ default['yum']['epel-source']['managed'] = false
 default['yum']['epel-testing']['repositoryid'] = 'epel-testing'
 default['yum']['epel-testing']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch'
 default['yum']['epel-testing']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch'
-default['yum']['epel-testing']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6r'
+default['yum']['epel-testing']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6r'
 default['yum']['epel-testing']['failovermethod'] = 'priority'
 default['yum']['epel-testing']['gpgcheck'] = true
 default['yum']['epel-testing']['enabled'] = false
@@ -83,7 +83,7 @@ default['yum']['epel-testing']['managed'] = false
 default['yum']['epel-testing-debuginfo']['repositoryid'] = 'epel-testing-debuginfo'
 default['yum']['epel-testing-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch Debug'
 default['yum']['epel-testing-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch'
-default['yum']['epel-testing-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-testing-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-testing-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-testing-debuginfo']['gpgcheck'] = true
 default['yum']['epel-testing-debuginfo']['enabled'] = false
@@ -94,7 +94,7 @@ default['yum']['epel-testing-debuginfo']['managed'] = false
 default['yum']['epel-testing-source']['repositoryid'] = 'epel-testing-source'
 default['yum']['epel-testing-source']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch Source'
 default['yum']['epel-testing-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch'
-default['yum']['epel-testing-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-testing-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-testing-source']['failovermethod'] = 'priority'
 default['yum']['epel-testing-source']['gpgcheck'] = true
 default['yum']['epel-testing-source']['enabled'] = false
@@ -113,7 +113,7 @@ default['yum']['epel-testing-source']['managed'] = false
     description 'Extra Packages for Enterprise Linux 5 - $basearch'
     enabled true
     gpgcheck true
-    gpgkey 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
+    gpgkey 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
   end
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ default['yum-epel']['repos'] = %w(
 default['yum']['epel']['repositoryid'] = 'epel'
 default['yum']['epel']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch'
 default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-5&arch=$basearch'
-default['yum']['epel']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel']['failovermethod'] = 'priority'
 default['yum']['epel']['gpgcheck'] = true
 default['yum']['epel']['enabled'] = true
@@ -50,7 +50,7 @@ default['yum']['epel']['managed'] = true
 default['yum']['epel-debuginfo']['repositoryid'] = 'epel-debuginfo'
 default['yum']['epel-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Debug'
 default['yum']['epel-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch'
-default['yum']['epel-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-debuginfo']['gpgcheck'] = true
 default['yum']['epel-debuginfo']['enabled'] = false
@@ -61,7 +61,7 @@ default['yum']['epel-debuginfo']['managed'] = false
 default['yum']['epel-source']['repositoryid'] = 'epel-source'
 default['yum']['epel-source']['description'] = 'Extra Packages for Enterprise Linux 6 - $basearch - Source'
 default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=$basearch'
-default['yum']['epel-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-source']['failovermethod'] = 'priority'
 default['yum']['epel-source']['gpgcheck'] = true
 default['yum']['epel-source']['enabled'] = false
@@ -72,7 +72,7 @@ default['yum']['epel-source']['managed'] = false
 default['yum']['epel-testing']['repositoryid'] = 'epel-testing'
 default['yum']['epel-testing']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch'
 default['yum']['epel-testing']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-epel6&arch=$basearch'
-default['yum']['epel-testing']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6r'
+default['yum']['epel-testing']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6r'
 default['yum']['epel-testing']['failovermethod'] = 'priority'
 default['yum']['epel-testing']['gpgcheck'] = true
 default['yum']['epel-testing']['enabled'] = false
@@ -83,7 +83,7 @@ default['yum']['epel-testing']['managed'] = false
 default['yum']['epel-testing-debuginfo']['repositoryid'] = 'epel-testing-debuginfo'
 default['yum']['epel-testing-debuginfo']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch Debug'
 default['yum']['epel-testing-debuginfo']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-debug-epel6&arch=$basearch'
-default['yum']['epel-testing-debuginfo']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-testing-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-testing-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-testing-debuginfo']['gpgcheck'] = true
 default['yum']['epel-testing-debuginfo']['enabled'] = false
@@ -94,7 +94,7 @@ default['yum']['epel-testing-debuginfo']['managed'] = false
 default['yum']['epel-testing-source']['repositoryid'] = 'epel-testing-source'
 default['yum']['epel-testing-source']['description'] = 'Extra Packages for Enterprise Linux 6 - Testing - $basearch Source'
 default['yum']['epel-testing-source']['mirrorlist'] = 'https://mirrors.fedoraproject.org/metalink?repo=testing-source-epel6&arch=$basearch'
-default['yum']['epel-testing-source']['gpgkey'] = 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+default['yum']['epel-testing-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
 default['yum']['epel-testing-source']['failovermethod'] = 'priority'
 default['yum']['epel-testing-source']['gpgcheck'] = true
 default['yum']['epel-testing-source']['enabled'] = false
@@ -113,7 +113,7 @@ default['yum']['epel-testing-source']['managed'] = false
     description 'Extra Packages for Enterprise Linux 5 - $basearch'
     enabled true
     gpgcheck true
-    gpgkey 'http://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
+    gpgkey 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL'
   end
 ```
 

--- a/attributes/epel-debuginfo.rb
+++ b/attributes/epel-debuginfo.rb
@@ -4,14 +4,14 @@ default['yum']['epel-debuginfo']['description'] = "Extra Packages for #{node['pl
 if platform?('amazon')
   if node['platform_version'].to_i > 2010
     default['yum']['epel-debuginfo']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-6&arch=$basearch'
-    default['yum']['epel-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   else
     default['yum']['epel-debuginfo']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-7&arch=$basearch'
-    default['yum']['epel-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 else
   default['yum']['epel-debuginfo']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-debug-#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-debuginfo']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  default['yum']['epel-debuginfo']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 end
 default['yum']['epel-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-debuginfo']['gpgcheck'] = true

--- a/attributes/epel-source.rb
+++ b/attributes/epel-source.rb
@@ -4,14 +4,14 @@ default['yum']['epel-source']['description'] = "Extra Packages for #{node['platf
 if platform?('amazon')
   if node['platform_version'].to_i > 2010
     default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-6&arch=$basearch'
-    default['yum']['epel-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   else
     default['yum']['epel-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-7&arch=$basearch'
-    default['yum']['epel-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 else
   default['yum']['epel-source']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-source-#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-source']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  default['yum']['epel-source']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 end
 default['yum']['epel-source']['failovermethod'] = 'priority'
 default['yum']['epel-source']['gpgcheck'] = true

--- a/attributes/epel-testing-debuginfo.rb
+++ b/attributes/epel-testing-debuginfo.rb
@@ -4,14 +4,14 @@ default['yum']['epel-testing-debuginfo']['description'] = "Extra Packages for #{
 if platform?('amazon')
   if node['platform_version'].to_i > 2010
     default['yum']['epel-testing-debuginfo']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel6&arch=$basearch'
-    default['yum']['epel-testing-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-testing-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   else
     default['yum']['epel-testing-debuginfo']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel7&arch=$basearch'
-    default['yum']['epel-testing-debuginfo']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-testing-debuginfo']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 else
   default['yum']['epel-testing-debuginfo']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-debug-epel#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-testing-debuginfo']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  default['yum']['epel-testing-debuginfo']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 end
 default['yum']['epel-testing-debuginfo']['failovermethod'] = 'priority'
 default['yum']['epel-testing-debuginfo']['gpgcheck'] = true

--- a/attributes/epel-testing-source.rb
+++ b/attributes/epel-testing-source.rb
@@ -4,14 +4,14 @@ default['yum']['epel-testing-source']['description'] = "Extra Packages for #{nod
 if platform?('amazon')
   if node['platform_version'].to_i > 2010
     default['yum']['epel-testing-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel6&arch=$basearch'
-    default['yum']['epel-testing-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-testing-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   else
     default['yum']['epel-testing-source']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel7&arch=$basearch'
-    default['yum']['epel-testing-source']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-testing-source']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 else
   default['yum']['epel-testing-source']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-source-epel#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-testing-source']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  default['yum']['epel-testing-source']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 end
 default['yum']['epel-testing-source']['failovermethod'] = 'priority'
 default['yum']['epel-testing-source']['gpgcheck'] = true

--- a/attributes/epel-testing.rb
+++ b/attributes/epel-testing.rb
@@ -4,14 +4,14 @@ default['yum']['epel-testing']['description'] = "Extra Packages for #{node['plat
 if platform?('amazon')
   if node['platform_version'].to_i > 2010
     default['yum']['epel-testing']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=$basearch'
-    default['yum']['epel-testing']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+    default['yum']['epel-testing']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
   else
     default['yum']['epel-testing']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel7&arch=$basearch'
-    default['yum']['epel-testing']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+    default['yum']['epel-testing']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
   end
 else
   default['yum']['epel-testing']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel#{node['platform_version'].to_i}&arch=$basearch"
-  default['yum']['epel-testing']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+  default['yum']['epel-testing']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
 end
 default['yum']['epel-testing']['failovermethod'] = 'priority'
 default['yum']['epel-testing']['gpgcheck'] = true

--- a/attributes/epel.rb
+++ b/attributes/epel.rb
@@ -12,14 +12,14 @@ else
   if platform?('amazon')
     if node['platform_version'].to_i > 2010
       default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=$basearch'
-      default['yum']['epel']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
+      default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6'
     else
       default['yum']['epel']['mirrorlist'] = 'http://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch'
-      default['yum']['epel']['gpgkey'] = 'http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
+      default['yum']['epel']['gpgkey'] = 'https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7'
     end
   else
     default['yum']['epel']['mirrorlist'] = "http://mirrors.fedoraproject.org/mirrorlist?repo=epel-#{node['platform_version'].to_i}&arch=$basearch"
-    default['yum']['epel']['gpgkey'] = "https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
+    default['yum']['epel']['gpgkey'] = "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-#{node['platform_version'].to_i}"
   end
 end
 default['yum']['epel']['failovermethod'] = 'priority'


### PR DESCRIPTION
### Description

Switch from http://download or https://download to https://dl

Only impact new repo setup. Previously retrieved keys still work.

Looks like EPEL group disabled/shutdown download sub-domain name
on or about Feb 23-25, 2019 as the old download. worked on Feb 22, 2019

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

Signed-off-by: Wade Peacock <wade.peacock@visioncritical.com>